### PR TITLE
Add support for Markdown heading tokenization

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -6,17 +6,105 @@ export type Token = {
     line: number;
   };
 };
+
 export interface LexerOptions {}
 
+/**
+ * Lexer class is responsible for tokenizing a given input string
+ * into an array of tokens based on specific rules defined for
+ * token types such as headings.
+ */
 export class Lexer {
-  private options: LexerOptions;
+  private options: LexerOptions; // Options for the lexer configuration
+  private input: string = ""; // The input string to be tokenized
 
+  /**
+   * Constructs a new Lexer instance with the provided options.
+   *
+   * @param options - Configuration options for the lexer.
+   */
   constructor(options: LexerOptions) {
     this.options = options;
   }
 
+  /**
+   * Sets the input string to be tokenized.
+   *
+   * @param input - The input string to be processed.
+   */
+  public setInput(input: string): void {
+    this.input = input;
+  }
+
+  /**
+   * Tokenizes the input string and returns an array of tokens.
+   *
+   * @returns An array of tokens extracted from the input string.
+   */
   public tokenize(): Token[] {
-    return [];
+    const tokens: Token[] = []; // Array to hold the generated tokens
+    let line = 1; // Current line number
+    let column = 1; // Current column number
+    let position = 0; // Current position in the input string
+
+    while (position < this.input.length) {
+      // Handle new line characters
+      if (this.input[position] === "\n") {
+        line++;
+        column = 1;
+        position++;
+        continue;
+      }
+
+      // Attempt to match a heading token
+      const headingToken = this.matchHeading(
+        this.input,
+        position,
+        line,
+        column
+      );
+      if (headingToken) {
+        tokens.push(headingToken); // Add the matched token to the array
+        position += headingToken.value.length; // Update position
+        column += headingToken.value.length; // Update column
+        continue;
+      }
+
+      position++; // Move to the next character
+      column++; // Increment column count
+    }
+
+    return tokens; // Return the array of tokens
+  }
+
+  /**
+   * Matches a heading token in the input string starting from a given position.
+   *
+   * @param input - The input string to search within.
+   * @param position - The current position in the input string.
+   * @param line - The current line number.
+   * @param column - The current column number.
+   * @returns A Token object if a heading is matched, otherwise null.
+   */
+  private matchHeading(
+    input: string,
+    position: number,
+    line: number,
+    column: number
+  ): Token | null {
+    const match = input.slice(position).match(/^(#{1,6})\s+(.*)/); // Regex to match headings
+    if (match) {
+      const [matched, hashes, text] = match; // Destructure the match result
+      return {
+        type: `HEADING_${hashes.length}`, // Determine the token type based on the number of hashes
+        value: matched, // The matched heading text
+        location: {
+          line, // Line number of the token
+          column // Column number of the token
+        }
+      };
+    }
+    return null; // Return null if no heading is matched
   }
 }
 

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -1,11 +1,11 @@
-import Lexer, { LexerOptions } from "../src/lexer";
+import Lexer, { LexerOptions, Token } from "../src/lexer";
 
 describe("Lexer", () => {
   let options: LexerOptions;
   let lexer: Lexer;
 
   beforeEach(() => {
-    options = {}; // Mock options
+    options = {};
     lexer = new Lexer(options);
   });
 
@@ -20,5 +20,109 @@ describe("Lexer", () => {
 
   test("should initialize options correctly", () => {
     expect(lexer["options"]).toBe(options);
+  });
+
+  test("should have setInput method", () => {
+    expect(lexer.setInput).toBeDefined();
+    expect(typeof lexer.setInput).toBe("function");
+  });
+
+  test("should set input correctly", () => {
+    const input = "# Hello, World!";
+    lexer.setInput(input);
+    expect(lexer["input"]).toBe(input);
+  });
+
+  test("should have a matchHeading method", () => {
+    expect(lexer["matchHeading"]).toBeDefined();
+    expect(typeof lexer["matchHeading"]).toBe("function");
+  });
+
+  test("should tokenize an empty string", () => {
+    let tokens: Token[] = [];
+    lexer.setInput("");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([]);
+  });
+
+  test("should tokenize a headings", () => {
+    let tokens: Token[] = [];
+    lexer.setInput("# Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_1",
+        value: "# Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
+
+    lexer.setInput("## Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_2",
+        value: "## Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
+
+    lexer.setInput("### Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_3",
+        value: "### Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
+
+    lexer.setInput("#### Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_4",
+        value: "#### Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
+
+    lexer.setInput("##### Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_5",
+        value: "##### Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
+
+    lexer.setInput("###### Hello, World!");
+    tokens = lexer.tokenize();
+    expect(tokens).toEqual([
+      {
+        type: "HEADING_6",
+        value: "###### Hello, World!",
+        location: {
+          line: 1,
+          column: 1
+        }
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Implement Lexer class with tokenization of headings; add tests for input handling and token generation of headings.

Syntax of the headings:
```md
# Heading1
## Heading 2
### Heading 3
#### Heading 4
##### Heading 5
###### Heading 6
```

closes #5 